### PR TITLE
Added ComputedPropertyNames feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,17 +84,17 @@ Object literals are extended to support setting the prototype at construction, s
 
 ```JavaScript
 var obj = {
-   // __proto__
-   __proto__: theProtoObj,
-   // Shorthand for ‘handler: handler’
-   handler,
-   // Methods
-   toString() {
+    // __proto__
+    __proto__: theProtoObj,
+    // Shorthand for ‘handler: handler’
+    handler,
+    // Methods
+    toString() {
      // Super calls
      return "d " + super.toString();
-   },
-   // Computed (dynamic) property names
-   [ 'prop_' + (() => 42)() ]: 42
+    },
+    // Computed (dynamic) property names
+    [ 'prop_' + (() => 42)() ]: 42
 };
 ```
 


### PR DESCRIPTION
Added [Computed Property Names](http://wiki.ecmascript.org/doku.php?id=harmony:object_literals#object_literal_computed_property_keys) feature for the Enhanced Object Literals section. The syntax highlighter seems to struggle a bit on those, sometimes the line is not showing up, so I had to re-indent the section (and [filed a bug](https://github.com/tmm1/pygments.rb/issues/115)).
