### PR TITLE
Removed comprehensions from feature list (deferred to ES7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ ES6 includes the following new features:
 - [let + const](#let--const)
 - [iterators + for..of](#iterators--forof)
 - [generators](#generators)
-- [comprehensions](#comprehensions)
 - [unicode](#unicode)
 - [modules](#modules)
 - [module loaders](#module-loaders)
@@ -267,25 +266,6 @@ interface Generator extends Iterator {
     next(value?: any): IteratorResult;
     throw(exception: any);
 }
-```
-
-### Comprehensions
-Array and generator comprehensions provide simple declarative list processing similar as used in many functional programming patterns.
-
-```JavaScript
-// Array comprehensions
-var results = [
-  for(c of customers)
-    if (c.city == "Seattle")
-      { name: c.name, age: c.age }
-]
-
-// Generator comprehensions
-var results = (
-  for(c of customers)
-    if (c.city == "Seattle")
-      { name: c.name, age: c.age }
-)
 ```
 
 ### Unicode


### PR DESCRIPTION
Comprehensions are deferred from the ES6 standard (and delayed to ES7 for syntax unification): https://github.com/rwaldron/tc39-notes/blob/master/es6/2014-07/jul-30.md#47-revisit-comprehension-decision-from-last-meeting