### PR TITLE
Replace print() with console.log() in code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ for (var n of fibonacci) {
   // truncate the sequence at 1000
   if (n > 1000)
     break;
-  print(n);
+  console.log(n);
 }
 ```
 
@@ -256,7 +256,7 @@ for (var n of fibonacci) {
   // truncate the sequence at 1000
   if (n > 1000)
     break;
-  print(n);
+  console.log(n);
 }
 ```
 


### PR DESCRIPTION
print() causes a print dialog on each iteration. 

For an interested reader this code would be really troublesome if he'd paste it into a REPL like http://babeljs.io/repl