### PR TITLE
Include Array.prototype.find example

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,8 @@ Math.imul(Math.pow(2, 32) - 1, Math.pow(2, 32) - 2) // 2
 Array.from(document.querySelectorAll('*')) // Returns a real Array
 Array.of(1, 2, 3) // Similar to new Array(...), but without special one-arg behavior
 [0, 0, 0].fill(7, 1) // [0,7,7]
-[1,2,3].findIndex(x => x == 2) // 1
+[1, 2, 3].find(x => x == 3) // 3
+[1, 2, 3].findIndex(x => x == 2) // 1
 ["a", "b", "c"].entries() // iterator [0, "a"], [1,"b"], [2,"c"]
 ["a", "b", "c"].keys() // iterator 0, 1, 2
 ["a", "b", "c"].values() // iterator "a", "b", "c"


### PR DESCRIPTION
Seems like a small omission, since `findIndex` was in there.