### PR TITLE
Fix Proxy examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,8 +395,8 @@ Proxies enable creation of objects with the full range of behaviors available to
 // Proxying a normal object
 var target = {};
 var handler = {
-  get: function (receiver, name) {
-    return `Hello, ${name}!`;
+  get: function (target, property, receiver) {
+    return `Hello, ${property}!`;
   }
 };
 
@@ -408,7 +408,7 @@ p.world === 'Hello, world!';
 // Proxying a function object
 var target = function () { return 'I am the target'; };
 var handler = {
-  apply: function (receiver, ...args) {
+  apply: function (thisArg, args) {
     return 'I am the proxy';
   }
 };


### PR DESCRIPTION
the [[Get]] internal slot of Proxy [calls the handler](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver) with `target`, `P`, and `receiver` as arguments.

the [[Call]] internal slot [calls the handler] with `thisArgument` and an `argsList` which is an Array made from the argumentsList. You don't need to use a rest parameter there.
