### PR TITLE
add some definition statements in the chapter of Arrows

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,14 @@ Arrows are a function shorthand using the `=>` syntax.  They are syntactically s
 
 ```JavaScript
 // Expression bodies
+var evens = [1, 2, 3];
 var odds = evens.map(v => v + 1);
 var nums = evens.map((v, i) => v + i);
 var pairs = evens.map(v => ({even: v, odd: v + 1}));
 
 // Statement bodies
+var nums = [1, 5, 7, 10];
+var fives = []
 nums.forEach(v => {
   if (v % 5 === 0)
     fives.push(v);
@@ -48,7 +51,7 @@ nums.forEach(v => {
 // Lexical this
 var bob = {
   _name: "Bob",
-  _friends: [],
+  _friends: ["Alice", "Jack"],
   printFriends() {
     this._friends.forEach(f =>
       console.log(this._name + " knows " + f));

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Arrows are a function shorthand using the `=>` syntax.  They are syntactically s
 
 ```JavaScript
 // Expression bodies
-var evens = [1, 2, 3];
+var evens = [2, 4, 6];
 var odds = evens.map(v => v + 1);
 var nums = evens.map((v, i) => v + i);
 var pairs = evens.map(v => ({even: v, odd: v + 1}));


### PR DESCRIPTION
When the first time I was learning the es6features. I directly copy the code
```
var odds = evens.map(v => v + 1);
var nums = evens.map((v, i) => v + i);
var pairs = evens.map(v => ({even: v, odd: v + 1}));
```
to the console page of my chromium web browser's developer tools.   
Without doubt, the errors shows like this:
```
VM347:1 Uncaught ReferenceError: evens is not defined
    at <anonymous>:1:12
(anonymous) @ VM347:1
```
Which is very disappointing.
So I add the definition statement like `var evens = [2, 4, 6];`.  
I think some extra definition statements will make it feel better especially for new users.