### PR TITLE
Add semicolons to "... APIs" part

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,28 +530,28 @@ arr.length == 2
 Many new library additions, including core Math libraries, Array conversion helpers, String helpers, and Object.assign for copying.
 
 ```JavaScript
-Number.EPSILON
-Number.isInteger(Infinity) // false
-Number.isNaN("NaN") // false
+Number.EPSILON;
+Number.isInteger(Infinity); // false
+Number.isNaN("NaN"); // false
 
-Math.acosh(3) // 1.762747174039086
-Math.hypot(3, 4) // 5
-Math.imul(Math.pow(2, 32) - 1, Math.pow(2, 32) - 2) // 2
+Math.acosh(3); // 1.762747174039086
+Math.hypot(3, 4); // 5
+Math.imul(Math.pow(2, 32) - 1, Math.pow(2, 32) - 2); // 2
 
-"abcde".includes("cd") // true
-"abc".repeat(3) // "abcabcabc"
+"abcde".includes("cd"); // true
+"abc".repeat(3); // "abcabcabc"
 
-Array.from(document.querySelectorAll('*')) // Returns a real Array
-Array.of(1, 2, 3) // Similar to new Array(...), but without special one-arg behavior
-[0, 0, 0].fill(7, 1) // [0,7,7]
-[1, 2, 3].find(x => x == 3) // 3
-[1, 2, 3].findIndex(x => x == 2) // 1
-[1, 2, 3, 4, 5].copyWithin(3, 0) // [1, 2, 3, 1, 2]
-["a", "b", "c"].entries() // iterator [0, "a"], [1,"b"], [2,"c"]
-["a", "b", "c"].keys() // iterator 0, 1, 2
-["a", "b", "c"].values() // iterator "a", "b", "c"
+Array.from(document.querySelectorAll('*')); // Returns a real Array
+Array.of(1, 2, 3); // Similar to new Array(...), but without special one-arg behavior
+[0, 0, 0].fill(7, 1); // [0,7,7]
+[1, 2, 3].find(x => x == 3); // 3
+[1, 2, 3].findIndex(x => x == 2); // 1
+[1, 2, 3, 4, 5].copyWithin(3, 0); // [1, 2, 3, 1, 2]
+["a", "b", "c"].entries(); // iterator [0, "a"], [1,"b"], [2,"c"]
+["a", "b", "c"].keys(); // iterator 0, 1, 2
+["a", "b", "c"].values(); // iterator "a", "b", "c"
 
-Object.assign(Point, { origin: new Point(0,0) })
+Object.assign(Point, { origin: new Point(0,0) });
 ```
 
 More MDN info: [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number), [Math](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math), [Array.from](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from), [Array.of](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/of), [Array.prototype.copyWithin](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin), [Object.assign](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign)


### PR DESCRIPTION
Once examples is executed as a whole code block,

```JavaScript
Array.of(1, 2, 3)
[0, 0, 0].fill(7, 1)
```

will be treated as

```JavaScript
Array.of(1, 2, 3)[0, 0, 0].fill(7, 1)
```

which is not as hoped.