### PR TITLE
Fixed introduction saying "ES6 is latest version of ECMAScript standard"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ECMAScript 6 <sup>[git.io/es6features](http://git.io/es6features)</sup>
 
 ## Introduction
-ECMAScript 6, also known as ECMAScript 2015, is the latest version of the ECMAScript standard.  ES6 is a significant update to the language, and the first update to the language since ES5 was standardized in 2009. Implementation of these features in major JavaScript engines is [underway now](http://kangax.github.io/es5-compat-table/es6/).
+ECMAScript 6, also known as ECMAScript 2015, is a significant update to the language, and the first update to the language since ES5 was standardized in 2009. Implementation of these features in major JavaScript engines is [underway now](http://kangax.github.io/es5-compat-table/es6/).
 
 See the [ES6 standard](http://www.ecma-international.org/ecma-262/6.0/) for full specification of the ECMAScript 6 language.
 


### PR DESCRIPTION
It was written in the Introduction that ES6 is latest version of ECMAScript standard. It's wrong because the latest version of ECMAScript standard is ES8.