### PR TITLE
Tail Calls example bug resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,7 +599,6 @@ Calls in tail-position are guaranteed to not grow the stack unboundedly.  Makes 
 
 ```JavaScript
 function factorial(n, acc = 1) {
-    'use strict';
     if (n <= 1) return acc;
     return factorial(n - 1, n * acc);
 }


### PR DESCRIPTION
# Remove the  'use strict' keyword  inside the factorial function
# Error: 
-  Firefox: Uncaught SyntaxError: "use strict" not allowed in function with default parameter
-  Chrome: Uncaught SyntaxError: Illegal 'use strict' directive in function with non-simple parameter list